### PR TITLE
Render children in StructureComponentInner to allow useComponent hook to be used in children

### DIFF
--- a/src/components/StructureComponent/StructureComponentInner.tsx
+++ b/src/components/StructureComponent/StructureComponentInner.tsx
@@ -8,6 +8,7 @@ export interface StructureComponentInnerProps {
 
 export const StructureComponentInner: React.FC<StructureComponentInnerProps> = ({
   selection = '',
+  children,
 }) => {
   const component = useComponent();
   if (!(component instanceof NGL.StructureComponent)) {
@@ -20,5 +21,5 @@ export const StructureComponentInner: React.FC<StructureComponentInnerProps> = (
     component.setSelection(selection);
   }, [component, selection]);
 
-  return null;
+  return <>{children}</>;
 };


### PR DESCRIPTION
Hi there

I didn't fully test this, but I was trying to use the StructureComponent (e.g. to draw a selection like only amino acids 0-90) but I also wanted to have a hook that had useComponent so I had



```
const ComponentChild = () => {
    const component = useComponent
    useEffect(() => { /* do stuff with component */ })
}

const OtherThing = () => {
    return <StructureComponent><ComponentChild/></StructureComponent>
}
```

I believe that the ComponentChild does not get rendered by this however, as console.logs in the function body are never called

This PR tries to address this