### PR TITLE
Allow reprList to be uncontrolled

### DIFF
--- a/src/components/Component/Component.tsx
+++ b/src/components/Component/Component.tsx
@@ -34,7 +34,7 @@ export const Component: React.FC<ComponentProps> = ({
   path,
   loadFileParams,
   params = ComponentDefaultParameters,
-  reprList = [],
+  reprList = undefined,
   position = defaultPosition,
   quaternion = defaultQuaternion,
   scale = defaultScale,
@@ -88,7 +88,7 @@ export const Component: React.FC<ComponentProps> = ({
   }, [component, params]);
 
   useEffect(() => {
-    if (component) {
+    if (component && reprList) {
       component.removeAllRepresentations();
       reprList.forEach((repr) =>
         component.addRepresentation(repr.type, repr.params)


### PR DESCRIPTION
Fixes #22.

Allowing `reprList` to be an uncontrolled prop.
That is, this PR changes default prop for `reprList` of Component from `[]` to `undefined` and changes the useEffect section to skip updating representations if `reprList` is `undefined`.