### PR TITLE
Fixed prop types for compatibilty with react 18

### DIFF
--- a/src/components/Component/Component.tsx
+++ b/src/components/Component/Component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, PropsWithChildren } from 'react';
 import useAsyncEffect from '@n1ru4l/use-async-effect';
 import { NGL, RepresentationDescriptor, mergeParams } from '../../utils';
 import { useStage, ComponentReactContext } from '../../hooks';
@@ -29,7 +29,7 @@ export interface ComponentProps {
   onLoadFailure?: (error: Error) => void;
 }
 
-export const Component: React.FC<ComponentProps> = ({
+export const Component: React.FC<PropsWithChildren<ComponentProps>> = ({
   children,
   path,
   loadFileParams,
@@ -55,8 +55,10 @@ export const Component: React.FC<ComponentProps> = ({
           | NGL.Component
           | undefined;
       } catch (error) {
-        if (onLoadFailure) {
-          onLoadFailure(error);
+        if(error instanceof Error){
+          if (onLoadFailure) {
+            onLoadFailure(error);
+          }
         }
       }
       if (nextComponent) {

--- a/src/components/Stage/Stage.tsx
+++ b/src/components/Stage/Stage.tsx
@@ -4,6 +4,7 @@ import React, {
   useRef,
   useState,
   RefCallback,
+  PropsWithChildren
 } from 'react';
 import { StageReactContext } from '../../hooks';
 import {
@@ -25,7 +26,7 @@ export interface StageProps {
   onCameraMove?: (cameraState: Partial<CameraState>) => void;
 }
 
-export const Stage: React.FC<StageProps> = ({
+export const Stage: React.FC<PropsWithChildren<StageProps>> = ({
   children,
   width,
   height,

--- a/src/components/Stage/Viewer.tsx
+++ b/src/components/Stage/Viewer.tsx
@@ -1,10 +1,10 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 // import { useStage } from '../../hooks';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface ViewerProps {}
 
-export const Viewer: React.FC<ViewerProps> = ({ children }) => {
+export const Viewer: React.FC<PropsWithChildren<ViewerProps>> = ({ children }) => {
   // const stage = useStage();
   // const { viewer } = stage;
 

--- a/src/components/StructureComponent/StructureComponent.tsx
+++ b/src/components/StructureComponent/StructureComponent.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {PropsWithChildren} from 'react';
 import { ComponentProps, Component } from '../Component/Component';
 import {
   StructureComponentInner,
@@ -9,7 +9,7 @@ export interface StructureComponentProps
   extends StructureComponentInnerProps,
     ComponentProps {}
 
-export const StructureComponent: React.FC<StructureComponentProps> = ({
+export const StructureComponent: React.FC<PropsWithChildren<StructureComponentProps>> = ({
   children,
   selection,
   ...componentProps

--- a/src/components/StructureComponent/StructureComponentInner.tsx
+++ b/src/components/StructureComponent/StructureComponentInner.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { PropsWithChildren, useEffect } from 'react';
 import { useComponent } from '../../hooks';
 import { NGL } from '../../utils';
 
@@ -6,7 +6,7 @@ export interface StructureComponentInnerProps {
   selection?: string;
 }
 
-export const StructureComponentInner: React.FC<StructureComponentInnerProps> = ({
+export const StructureComponentInner: React.FC<PropsWithChildren<StructureComponentInnerProps>> = ({
   selection = '',
   children,
 }) => {


### PR DESCRIPTION
children prop was removed from the FunctionComponent type in react 18 and throws an error when React Nodes are passed,
Added PropsWithChildren type to fix this